### PR TITLE
fix(week4): set development as default provider.

### DIFF
--- a/week4/deploy.js
+++ b/week4/deploy.js
@@ -9,7 +9,7 @@ const providerRPC = {
    development: 'http://localhost:9933',
    moonbase: 'https://rpc.api.moonbase.moonbeam.network',
 };
-const web3 = new Web3(providerRPC.moonbase); //Change to correct network
+const web3 = new Web3(providerRPC.development); //Change to correct network
 
 // Variables
 const account_from = {


### PR DESCRIPTION
The default provider address should be consistent with other scripts.

_Please note that the last line was also [changed by git](https://stackoverflow.com/questions/1967370/git-replacing-lf-with-crlf). It was not intended but also can't be avoided :)._